### PR TITLE
#46 Add send_message method to GameAPI, etc

### DIFF
--- a/engine/model/messages.py
+++ b/engine/model/messages.py
@@ -1,0 +1,7 @@
+
+
+class Messages:
+    """A collection of messages."""
+
+    def __init__(self):
+        self._messages = []

--- a/engine/scripts.py
+++ b/engine/scripts.py
@@ -37,6 +37,14 @@ class KeyPoint:
     properties: Dict[str, Any]
 
 
+@dataclasses.dataclass
+class Message:
+    """Represents a message to the player."""
+
+    message: str
+    creation_time: float
+
+
 class GameAPI(Protocol):
     """A protocol for how game objects will interact with the engine."""
 
@@ -78,6 +86,10 @@ class GameAPI(Protocol):
     @property
     def current_time_secs(self) -> float:
         """Gets the current time in seconds."""
+
+    def send_message(self, message: str) -> None:
+        """Sends a message to the player."""
+
 
 
 GameCallable = Callable[[GameAPI], None]


### PR DESCRIPTION
Fixes #46
Addresses first 3 bullets of the issue. I just want to make sure I am off to a solid start. 

- Add a send_message method to GameAPI that has a single argument: the string to show.

- Create a message data class that has two fields: the contents, and the creation time (in game time).

- Have the model contain a list of these message objects.